### PR TITLE
Extract template compilation from `loadTemplate()` to `compileTemplate()`

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -69,6 +69,23 @@ extend(ExpressHandlebars.prototype, {
 
     // -- Public Methods -------------------------------------------------------
 
+    compileTemplate: function (template, options, callback) {
+        options || (options = {});
+
+        var compiler = options.precompiled ? 'precompile' : 'compile',
+            compile  = this.handlebars[compiler],
+            compiledTemplate;
+
+        try {
+            compiledTemplate = compile(template);
+        } catch (ex) {
+            callback(ex);
+            return;
+        }
+
+        callback(null, compiledTemplate);
+    },
+
     loadPartials: function (options, callback) {
         if (arguments.length < 2 && typeof options === 'function') {
             callback = options;
@@ -119,26 +136,21 @@ extend(ExpressHandlebars.prototype, {
 
         var precompiled = options.precompiled,
             cache       = precompiled ? this.precompiled : this.compiled,
-            template    = options.cache && cache[filePath],
-            compile;
+            template    = options.cache && cache[filePath];
+
+        function compileTemplate(file, callback) {
+            this.compileTemplate(file, options, callback);
+        }
 
         if (template) {
             callback(null, template);
             return;
         }
 
-        compile = this.handlebars[precompiled ? 'precompile' : 'compile'];
-
-        this._loadFile(filePath, options, function (err, file) {
-            if (err) { return callback(err); }
-
-            try {
-                template = cache[filePath] = compile(file);
-                callback(null, template);
-            } catch (ex) {
-                callback(ex);
-            }
-        });
+        async.waterfall([
+            this._loadFile.bind(this, filePath, options),
+            compileTemplate.bind(this)
+        ], callback);
     },
 
     loadTemplates: function (dirPath, options, callback) {
@@ -335,10 +347,12 @@ extend(ExpressHandlebars.prototype, {
 
         try {
             output = template(context, options);
-            callback(null, output);
         } catch (ex) {
             callback(ex);
+            return;
         }
+
+        callback(null, output);
     },
 
     _resolveLayoutPath: function (options) {


### PR DESCRIPTION
This provides a hook for customizing how templates are compiled, allowing for pre- and post- processing of templates compiled by the Handlebars compiler.

Fixes #39 
### Todos
- [x] Make code changes
- [ ] Update README docs
- [ ] Add HISTORY entry
- [ ] Test in real-world apps
