### PR TITLE
allow extensions to be named without a period

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -28,7 +28,9 @@ function ExpressHandlebars(config) {
     if ('extname'     in config) { this.extname     = config.extname;     }
     if ('layoutsDir'  in config) { this.layoutsDir  = config.layoutsDir;  }
     if ('partialsDir' in config) { this.partialsDir = config.partialsDir; }
-
+    
+    if(this.extname[0] !== '.') { this.extname = '.' + this.extname; }
+    
     this.defaultLayout = config.defaultLayout;
     this.handlebars    = handlebars;
     this.helpers       = config.helpers;


### PR DESCRIPTION
like the extension naming in express.
