### PR TITLE
Each partials dir can be namespaced.

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -28,9 +28,9 @@ function ExpressHandlebars(config) {
     if ('extname'     in config) { this.extname     = config.extname;     }
     if ('layoutsDir'  in config) { this.layoutsDir  = config.layoutsDir;  }
     if ('partialsDir' in config) { this.partialsDir = config.partialsDir; }
-    
+
     if(this.extname[0] !== '.') { this.extname = '.' + this.extname; }
-    
+
     this.defaultLayout = config.defaultLayout;
     this.handlebars    = handlebars;
     this.helpers       = config.helpers;
@@ -84,7 +84,12 @@ extend(ExpressHandlebars.prototype, {
             var loadTemplates = this.loadTemplates.bind(this);
 
             async.map(dirs, function (dir, callback) {
-                loadTemplates(dir, options, callback);
+                if (typeof dir === 'string') {
+                    dir = {dir: dir};
+                }
+                loadTemplates(dir.dir, options, function (err, templates) {
+                    callback(err, templates && {templates: templates, namespace: dir.namespace});
+                });
             }, callback);
         }
 
@@ -92,9 +97,9 @@ extend(ExpressHandlebars.prototype, {
             var getPartialName = this._getPartialName.bind(this),
                 partials;
 
-            partials = dirs.reduce(function (partials, templates) {
-                Object.keys(templates).forEach(function (filePath) {
-                    partials[getPartialName(filePath)] = templates[filePath];
+            partials = dirs.reduce(function (partials, dir) {
+                Object.keys(dir.templates).forEach(function (filePath) {
+                    partials[getPartialName(filePath, dir.namespace)] = dir.templates[filePath];
                 });
 
                 return partials;
@@ -246,10 +251,14 @@ extend(ExpressHandlebars.prototype, {
 
     // -- Private Methods ------------------------------------------------------
 
-    _getPartialName: function (filePath) {
+    _getPartialName: function (filePath, namespace) {
         var extRegex = new RegExp(this.extname + '$'),
             name     = filePath.replace(extRegex, ''),
             version  = this.handlebarsVersion;
+
+        if (namespace) {
+            name = namespace + '/' + name;
+        }
 
         // Fixes a Handlebars bug in versions prior to 1.0.rc.2 which caused
         // partials with "/"s in their name to not be found.


### PR DESCRIPTION
As stated in #20, having multiple `partialsDir` can introduce naming collisions. This pull request adds support for partials namespaces. Each `partialsDir` can optionally be specified as an object, with a `dir` and `namespace` properties. Example:

```
var partialsDir = [
  'local/views',
  {dir: '/otherPackage/shared/views', namespace: 'otherPackage'}
];
...
app.engine('handlebars', exphbs({partialsDir: partialsDir}));
```

If both `local/views` and `/otherPackage/shared/views` contain a template named `status.hbs`, they can be included like this in a view:

```
{{> status}}
{{> otherPackage/status}}
```
