### PR TITLE
Each partials dir can be namespaced (with Promises)

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -96,15 +96,24 @@ ExpressHandlebars.prototype.getPartials = function (options) {
             this.partialsDir : [this.partialsDir];
 
     partialsDirs = partialsDirs.map(function (dir) {
-        return this.getTemplates(dir, options);
+        var getTemplates = this.getTemplates.bind(this);
+        if (typeof dir === 'string') {
+            dir = {dir: dir};
+        }
+
+        return new Promise(function (resolve, reject) {
+            getTemplates(dir.dir, options).then(function (templates) {
+                resolve({templates: templates, namespace: dir.namespace});
+            }, reject);
+        });
     }, this);
 
     return Promise.all(partialsDirs).then(function (dirs) {
         var getPartialName = this._getPartialName.bind(this);
 
-        return dirs.reduce(function (partials, templates) {
-            Object.keys(templates).forEach(function (filePath) {
-                partials[getPartialName(filePath)] = templates[filePath];
+        return dirs.reduce(function (partials, dir) {
+            Object.keys(dir.templates).forEach(function (filePath) {
+                partials[getPartialName(filePath, dir.namespace)] = dir.templates[filePath];
             });
 
             return partials;
@@ -252,10 +261,14 @@ ExpressHandlebars.prototype._getFile = function (filePath, options) {
     });
 };
 
-ExpressHandlebars.prototype._getPartialName = function (filePath) {
+ExpressHandlebars.prototype._getPartialName = function (filePath, namespace) {
     var extRegex = new RegExp(this.extname + '$'),
         name     = filePath.replace(extRegex, ''),
         version  = this.handlebarsVersion;
+
+    if (namespace) {
+        name = namespace + '/' + name;
+    }
 
     // Fixes a Handlebars bug in versions prior to 1.0.rc.2 which caused
     // partials with "/"s in their name to not be found.


### PR DESCRIPTION
(this is a rewrite of https://github.com/ericf/express3-handlebars/pull/64, based on https://github.com/ericf/express3-handlebars/tree/promises)

As stated in #20, having multiple `partialsDir` can introduce naming collisions. This pull request adds support for partials namespaces. Each `partialsDir` can optionally be specified as an object, with a `dir` and `namespace` properties. Example:

```
var partialsDir = [
  'local/views',
  {dir: '/otherPackage/shared/views', namespace: 'otherPackage'}
];
...
app.engine('handlebars', exphbs({partialsDir: partialsDir}));
```

If both `local/views` and `/otherPackage/shared/views` contain a template named `status.hbs`, they can be included like this in a view:

```
{{> status}}
{{> otherPackage/status}}
```
