### PR TITLE
add hbs helper to enable extending css js in advanced example

### DIFF
--- a/examples/advanced/lib/helpers.js
+++ b/examples/advanced/lib/helpers.js
@@ -1,3 +1,16 @@
 exports.yell = function (msg) {
     return msg.toUpperCase();
 };
+
+var blocks = {};
+
+exports.block = function (name) {
+  var str = (blocks[name] || []).join("");
+  blocks[name] = [];
+  return str;
+};
+
+exports.extend = function (name, options) {
+  if (!blocks[name]) return;
+  blocks[name].push(options.fn(this));
+};

--- a/examples/advanced/views/home.handlebars
+++ b/examples/advanced/views/home.handlebars
@@ -1,3 +1,13 @@
+{{#extend "stylesheets"}}
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/normalize/3.0.1/normalize.css"/>
+{{/extend}}
+
 <h1>{{> page/title}}</h1>
 
 {{> page/nav}}
+
+{{#extend "scripts"}}
+  <script>
+    document.write('Hello world!');
+  </script>
+{{/extend}}

--- a/examples/advanced/views/layouts/main.handlebars
+++ b/examples/advanced/views/layouts/main.handlebars
@@ -3,10 +3,13 @@
 <head>
     <meta charset="utf-8" />
     <title>{{> page/title}}</title>
+
+    {{{block "stylesheets"}}}
 </head>
 <body>
 
     {{{body}}}
 
+    {{{block "scripts"}}}
 </body>
 </html>


### PR DESCRIPTION
Changes: 
- add block, extend hbs helper util for advanced example to show the ability to extend/customize js/css for different handlebars

Screenshot of the output
![screen shot 2014-08-06 at 4 20 08 pm](https://cloud.githubusercontent.com/assets/1945035/3835517/cb9548e2-1dc0-11e4-824b-3e1944583fd7.jpg)
