### PR TITLE
Fix partial name with namespace

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -76,8 +76,8 @@ ExpressHandlebars.prototype.getPartials = function (options) {
         // Support `partialsDir` collection with object entries that contain a
         // namespace.
         if (dir && typeof dir !== 'string') {
-            dir       = dir.dir;
             namespace = dir.namespace;
+            dir       = dir.dir;
         }
 
         return this.getTemplates(dir, options).then(function (templates) {

--- a/package.json
+++ b/package.json
@@ -31,11 +31,16 @@
     "glob": "^4.0.3",
     "graceful-fs": "^3.0.2",
     "handlebars": "^2.0.0-alpha.4",
+    "mocha": "^1.21.4",
     "promise": "^5.0.0",
-    "semver": "^3.0.1"
+    "semver": "^3.0.1",
+    "sinon": "^1.10.3"
   },
   "main": "index.js",
   "directories": {
     "lib": "./lib"
+  },
+  "scripts": {
+    "test": "./node_modules/.bin/mocha test"
   }
 }

--- a/test/namespace.js
+++ b/test/namespace.js
@@ -1,0 +1,33 @@
+'use_strict';
+
+var ExpressHandlebars = require('../lib/express-handlebars'),
+    Promise           = global.Promise || require('promise'),
+    assert            = require('assert'),
+    sinon             = require('sinon');
+
+describe('Namespace', function () {
+    it('should resolve partial names with namespace if provided on getPartials', function (done) {
+        var partialsDir = [
+            'no-namespace',
+            {dir: 'dir-a', namespace: 'namespace-a'},
+            {dir: 'dir-b', namespace: 'namespace-b'},
+        ];
+        var expressHandlebars = new ExpressHandlebars({
+            partialsDir: partialsDir,
+        });
+
+        sinon.stub(expressHandlebars, '_getFile').returns(Promise.resolve(''));
+
+        var _getDirStub = sinon.stub(expressHandlebars, '_getDir');
+
+        _getDirStub.withArgs(sinon.match('no-namespace')).returns(Promise.resolve(['file-no-namespace']));
+        _getDirStub.withArgs(sinon.match('dir-a')).returns(Promise.resolve(['file-a']));
+        _getDirStub.withArgs(sinon.match('dir-b')).returns(Promise.resolve(['file-b']));
+
+        expressHandlebars.getPartials().then(function (partials) {
+            assert.ok(partials.hasOwnProperty('file-no-namespace'));
+            assert.ok(partials.hasOwnProperty('namespace-a/file-a'));
+            assert.ok(partials.hasOwnProperty('namespace-b/file-b'));
+        }).then(done, done);
+    });
+});


### PR DESCRIPTION
Because namespace assignment was occurring after `dir = dir.dir`,
there was never a `dir.namespace`. Had to put namespace before dir
get its new value.

Also I took the liberty of adding an unit test for this bug fix.

PS: I work at Yahoo.
