### PR TITLE
Allow each partials dir to be configured

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -71,19 +71,23 @@ ExpressHandlebars.prototype.getPartials = function (options) {
             this.partialsDir : [this.partialsDir];
 
     partialsDirs = partialsDirs.map(function (dir) {
-        var dirOptions = options;
+        var templates;
+        var namespace;
 
         // Support `partialsDir` collection with object entries that contain a
-        // namespace.
+        // templates promise and a namespace.
         if (dir && typeof dir !== 'string') {
-            dirOptions = utils.extend({}, options, dir);
-            dir        = dir.dir;
+            templates = dir.templates;
+            namespace = dir.namespace;
+            dir       = dir.dir;
         }
 
-        return this.getTemplates(dir, dirOptions).then(function (templates) {
+        templates || (templates = this.getTemplates(dir, options));
+
+        return templates.then(function (templates) {
             return {
                 templates: templates,
-                namespace: dirOptions.namespace
+                namespace: namespace
             };
         });
     }, this);


### PR DESCRIPTION
Since each partials dir can be [specified as an object](https://github.com/ericf/express-handlebars/pull/70), each dir can be configured differently. This is useful for example to always cache distributed partials, that don't need to be reloaded at each request in development:

``` javascript
var hbs_config = {
  extname: '.hbs',
  partialsDir: [
    '/.../views',
    {dir: '/.../node_modules/third-party/views', namespace: 'third-party', cache: true}
  ],
  handlebars: Handlebars
};
var handlebars = express_handlebars.create( hbs_config );
```
