### PR TITLE
Update glob and follow symlinks when looking for partials

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -242,7 +242,7 @@ ExpressHandlebars.prototype._getDir = function (dirPath, options) {
     // Optimistically cache dir promise to reduce file system I/O, but remove
     // from cache if there was a problem.
     dir = cache[dirPath] = new Promise(function (resolve, reject) {
-        glob(pattern, {cwd: dirPath}, function (err, dir) {
+        glob(pattern, {cwd: dirPath, symlinks: true}, function (err, dir) {
             if (err) {
                 reject(err);
             } else {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "glob": "^4.0.3",
+    "glob": "^4.3.2",
     "graceful-fs": "^3.0.2",
     "handlebars": "^2.0.0",
     "promise": "^6.0.0",


### PR DESCRIPTION
Currently, partials don't follow symbolic links.

A common use case (and one we're using) is registering './bower_components' as a partials dir - which works fine - but then trying to use `bower link` (which creates a symbolic link to a local copy of the component repo) to develop locally between components.