### PR TITLE
Added option for using the file name for the partial key

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,37 @@ updated path as the `partialsDir` property in your configuration.
 strings, and/or config objects as described above. The namespacing feature is
 useful if multiple partials dirs are used and their file paths might clash.
 
+#### `fileNameAsPartialName=false`
+Boolean value used to determine whether the relative path of a template or the template's 
+file name will be used in setting the name (or key) of the partials. This allows for 
+componentization of your views like the *image-gallery* in the directory structure below 
+without needing to reference the path of the *image-gallery.handlebars* in a handlebars 
+template like this: `{{>image-gallery/image-gallery}}`. If `fileNameAsPartialName` is set 
+to `true` then you can reference the template like this: `{{>image-gallery}}`.
+
+**Directory Structure:**
+
+```
+.
+├── app.js
+└── views
+    ├── home
+    │   ├── home.handlebars
+    │   ├── home.scss
+    │   └── home.js
+    ├── image-gallery
+    │   ├── image-gallery.handlebars
+    │   ├── image-gallery.scss
+    │   └── image-gallery.js
+    └── layouts
+        └── main.handlebars
+
+```
+
+**Note:** If you set `fileNameAsPartialName` to `true` then the file names must be unique 
+to ensure you render the proper template.
+
+
 ### Properties
 
 The public API properties are provided via `ExpressHandlebars` instances. In

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -20,6 +20,7 @@ function ExpressHandlebars(config) {
     this.extname     = config.extname     || this.extname;
     this.layoutsDir  = config.layoutsDir  || this.layoutsDir;
     this.partialsDir = config.partialsDir || this.partialsDir;
+    this.fileNameAsPartial  = config.fileNameAsPartial   || false;
 
     this.handlebarsVersion =
             ExpressHandlebars.getHandlebarsSemver(this.handlebars);
@@ -155,7 +156,12 @@ ExpressHandlebars.prototype.getTemplates = function (dirPath, options) {
 
         return Promise.all(templates).then(function (templates) {
             return filePaths.reduce(function (map, filePath, i) {
-                map[filePath] = templates[i];
+                if(options.fileNameAsPartial === true){
+                    var fileName = filePath.replace(/\\/g,'/').replace(/.*\//,'');
+                    map[fileName] = templates[i];
+                } else {
+                    map[filePath] = templates[i];
+                }
                 return map;
             }, {});
         });
@@ -200,7 +206,8 @@ ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) 
     options = {
         cache      : options.cache,
         layout     : 'layout' in options ? options.layout : this.defaultLayout,
-        precompiled: false
+        precompiled: false,
+        fileNameAsPartial   : this.fileNameAsPartial
     };
 
     // Extend `options` with Handlebars-specific rendering options.

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -20,7 +20,7 @@ function ExpressHandlebars(config) {
     this.extname     = config.extname     || this.extname;
     this.layoutsDir  = config.layoutsDir  || this.layoutsDir;
     this.partialsDir = config.partialsDir || this.partialsDir;
-    this.fileNameAsPartial  = config.fileNameAsPartial   || false;
+    this.fileNameAsPartialName  = config.fileNameAsPartialName   || false;
 
     this.handlebarsVersion =
             ExpressHandlebars.getHandlebarsSemver(this.handlebars);
@@ -156,7 +156,7 @@ ExpressHandlebars.prototype.getTemplates = function (dirPath, options) {
 
         return Promise.all(templates).then(function (templates) {
             return filePaths.reduce(function (map, filePath, i) {
-                if(options.fileNameAsPartial === true){
+                if(options.fileNameAsPartialName === true){
                     var fileName = filePath.replace(/\\/g,'/').replace(/.*\//,'');
                     map[fileName] = templates[i];
                 } else {
@@ -207,7 +207,7 @@ ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) 
         cache      : options.cache,
         layout     : 'layout' in options ? options.layout : this.defaultLayout,
         precompiled: false,
-        fileNameAsPartial   : this.fileNameAsPartial
+        fileNameAsPartialName   : this.fileNameAsPartialName
     };
 
     // Extend `options` with Handlebars-specific rendering options.


### PR DESCRIPTION
View <a href="https://github.com/JasonTowner/express-handlebars#filenameaspartialnamefalse" target="_blank">README.md</a>
I added a configuration option to use the file name of the handlebar templates as the partial name regardless of directory structure. This supports having a sub-components directory structure where each sub-component is in it's own folder containing the handlebars template, scss, js, separate readme, etc. (see the screenshot below). 
![screen shot 2015-01-14 at 11 37 25 am](https://cloud.githubusercontent.com/assets/1108191/5744880/aa902528-9be1-11e4-902d-b1cbe6e3d5db.png)
While this is currently supported, the keys for these partials are `button/_button` and `error/_error` and this new option would set the partial keys to `_button` and `_error` respectively.
