### PR TITLE
compress html if desired

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -2,12 +2,13 @@
 
 var Promise = global.Promise || require('promise');
 
-var glob       = require('glob'),
-    Handlebars = require('handlebars'),
-    fs         = require('graceful-fs'),
-    path       = require('path'),
-    semver     = require('semver'),
-    utils      = require('./utils');
+var glob               = require('glob'),
+    Handlebars         = require('handlebars'),
+    fs                 = require('graceful-fs'),
+    path               = require('path'),
+    semver             = require('semver'),
+    utils              = require('./utils'),
+    compressionPattern = new RegExp('\>[\n\t ]+\<' , 'g' );
 
 module.exports = ExpressHandlebars;
 
@@ -20,6 +21,7 @@ function ExpressHandlebars(config) {
     this.extname     = config.extname     || this.extname;
     this.layoutsDir  = config.layoutsDir  || this.layoutsDir;
     this.partialsDir = config.partialsDir || this.partialsDir;
+    this.compress    = config.compress    || this.compress;
 
     this.handlebarsVersion =
             ExpressHandlebars.getHandlebarsSemver(this.handlebars);
@@ -219,7 +221,7 @@ ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) 
                 return this.render(layoutPath, context, options);
             }
 
-            return body;
+            return this.compress ? body.replace( compressionPattern, "><" ) : body;
         }.bind(this))
         .then(utils.passValue(callback))
         .catch(utils.passError(callback));


### PR DESCRIPTION
If ``compress`` is passed as true at the time of ``express-handlebars`` instantiation, ``engine`` would return compressed **markup**
```js
var exphbs = require('express-handlebars');
...
app.engine('html', exphbs({
    handlebars: handlebars,
    compress: true
}));
```