### PR TITLE
Allow partials to be loaded from symlinked dirs

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -236,8 +236,8 @@ ExpressHandlebars.prototype._getDir = function (dirPath, options) {
             return dir.concat();
         });
     }
-
-    var pattern = '**/*' + this.extname;
+    // Use two levels of glob to allow symlinks to be followed
+    var pattern = '**/**/*' + this.extname;
 
     // Optimistically cache dir promise to reduce file system I/O, but remove
     // from cache if there was a problem.


### PR DESCRIPTION
Uses `**/**/` as a glob pattern so that symlinks are followed