### PR TITLE
Add support for render-level partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,12 +558,13 @@ resulting string.
     pipe through the template, all helpers, and all partials. This is a side
     data channel.
 
-  * `[helpers]`: Render-level helpers should be merged with (and will override)
-    instance and global helper functions.
+  * `[helpers]`: Render-level helpers that will be used instead of any
+    instance-level helpers; these will be merged with (and will override) any
+    global Handlebars helper functions.
 
-  * `[partials]`: Render-level partials that override _all_ this instance's
-    partials. This is used internally as an optimization to avoid re-loading all
-    the partials.
+  * `[partials]`: Render-level partials that will be used instead of any
+    instance-level partials. This is used internally as an optimization to avoid
+    re-loading all the partials.
 
 #### `renderView(viewPath, options|callback, [callback])`
 
@@ -596,8 +597,12 @@ are rendered, and to signal this view engine on how it should behave, e.g.,
     pipe through the template, all helpers, and all partials. This is a side
     data channel.
 
-  * `[helpers]`: Render-level helpers should be merged with (and will override)
-    instance and global helper functions.
+  * `[helpers]`: Render-level helpers that will be merged with (and will
+    override) instance and global helper functions.
+
+  * `[partials]`: Render-level partials will be merged with (and will override)
+    instance and global partials. This should be a `{partialName: fn}` hash or
+    a Promise of an object with this shape.
 
   * `[layout]`: Optional string path to the Handlebars template file to be used
     as the "layout". This overrides any `defaultLayout` value. Passing a falsy

--- a/examples/advanced/server.js
+++ b/examples/advanced/server.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Promise = global.Promise || require('promise');
+
 var express = require('express'),
     exphbs  = require('../../'), // "express-handlebars"
     helpers = require('./lib/helpers');
@@ -89,7 +91,11 @@ app.get('/echo/:message?', exposeTemplates, function (req, res) {
         message: req.params.message,
 
         // Overrides which layout to use, instead of the defaul "main" layout.
-        layout: 'shared-templates'
+        layout: 'shared-templates',
+
+        partials: Promise.resolve({
+            echo: hbs.handlebars.compile('<p>ECHO: {{message}}</p>')
+        })
     });
 });
 

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -176,10 +176,8 @@ ExpressHandlebars.prototype.render = function (filePath, context, options) {
     ]).then(function (templates) {
         var template = templates[0],
             partials = templates[1],
+            helpers  = options.helpers || this.helpers,
             data     = options.data;
-
-        var helpers = options.helpers ||
-                utils.extend({}, this.handlebars.helpers, this.helpers);
 
         return this._renderTemplate(template, context, {
             data    : data,
@@ -190,11 +188,19 @@ ExpressHandlebars.prototype.render = function (filePath, context, options) {
 };
 
 ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) {
-    var context = options,
-        data    = options.data;
+    options || (options = {});
 
-    var helpers = utils.extend({},
-            this.handlebars.helpers, this.helpers, options.helpers);
+    var context = options;
+    var data    = options.data;
+
+    var helpers = utils.extend({}, this.helpers, options.helpers);
+
+    var partials = Promise.all([
+        this.getPartials({cache: options.cache}),
+        Promise.resolve(options.partials)
+    ]).then(function (partials) {
+        return utils.extend.apply(null, [{}].concat(partials));
+    });
 
     // Pluck-out ExpressHandlebars-specific options.
     options = {
@@ -207,7 +213,7 @@ ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) 
     utils.extend(options, {
         data    : data,
         helpers : helpers,
-        partials: this.getPartials(options)
+        partials: partials
     });
 
     this.render(viewPath, context, options)


### PR DESCRIPTION
The `renderView()` method now accepts render-level `partials` that are merged with the instance-level and global Handlebars partials. The option value is specified as object with the shape: `{partialName: fn}` or a Promise of such an object.

Fixes #82