### PR TITLE
Support for run-level partialsDir

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -52,7 +52,8 @@ ExpressHandlebars.prototype.getPartials = function (options) {
             this.partialsDir : [this.partialsDir];
 
     if (options.partialsDir){
-        partialsDirs.push(options.partialsDir);
+        partialsDirs = Array.isArray(options.partialsDir) ?
+            partialsDirs.concat(options.partialsDir) : partialsDirs.push(options.partialsDir);
     }
 
     partialsDirs = partialsDirs.map(function (dir) {

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -51,6 +51,10 @@ ExpressHandlebars.prototype.getPartials = function (options) {
     var partialsDirs = Array.isArray(this.partialsDir) ?
             this.partialsDir : [this.partialsDir];
 
+    if (options.partialsDir){
+        partialsDirs.push(options.partialsDir);
+    }
+
     partialsDirs = partialsDirs.map(function (dir) {
         var dirPath;
         var dirTemplates;
@@ -197,7 +201,7 @@ ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) 
 
     // Merge render-level and instance-level partials together.
     var partials = Promise.all([
-        this.getPartials({cache: options.cache}),
+        this.getPartials({cache: options.cache, partialsDir: options.partialsDir}),
         Promise.resolve(options.partials),
     ]).then(function (partials) {
         return utils.assign.apply(null, [{}].concat(partials));

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -52,8 +52,7 @@ ExpressHandlebars.prototype.getPartials = function (options) {
             this.partialsDir : [this.partialsDir];
 
     if (options.partialsDir){
-        partialsDirs = Array.isArray(options.partialsDir) ?
-            partialsDirs.concat(options.partialsDir) : partialsDirs.push(options.partialsDir);
+        partialsDirs = partialsDirs.concat(options.partialsDir);
     }
 
     partialsDirs = partialsDirs.map(function (dir) {


### PR DESCRIPTION
I'm developing a site with a 'themeable' single route (or group of route). This is so a we can customise a given page easily using partials as hooks. For the majority of the other pages (the administration backend) no additional partials are required. So I've added the ability to pass an additional partialsDir while calling res.render()

```javascript
res.render('viewer/index', {
        layout: false,
        partialsDir: req.theme.partialsDir,
    });
```

this overrides any default partials with the themes partials. I've also made it possible to send in array of partials.. 

```javascript
res.render('viewer/index', {
        layout: false,
        partialsDir: [req.theme.partialsDir, req.default.partialsDir]
    });
```
