### PR TITLE
Add support for array as views

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -333,13 +333,13 @@ ExpressHandlebars.prototype._getView = function(viewsPath, viewPath) {
   }
   
   var self = this;
-  var stripFilename = /\/[^\/\\]+?$/;
+  var stripFilename = /[\/\\][^\/\\]+?$/;
   
   // Stripping filename (rather than indexOf) in case there are
   // multiple views folders in the same parent directory
   
   viewsPath.forEach(function(viewDir) {
-    if (viewDir === viewPath.replace(stripFilename, '')) {
+    if (viewDir === path.normalize(viewPath).replace(stripFilename, '')) {
      return self._getTemplateName(path.relative(viewDir, viewPath));
     }
   });

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -327,18 +327,6 @@ ExpressHandlebars.prototype._getTemplateName = function (filePath, namespace) {
     return name;
 };
 
-ExpressHandlebars.prototype._resolveLayoutPath = function (layoutPath) {
-    if (!layoutPath) {
-        return null;
-    }
-
-    if (!path.extname(layoutPath)) {
-        layoutPath += this.extname;
-    }
-
-    return path.resolve(this.layoutsDir, layoutPath);
-};
-
 ExpressHandlebars.prototype._getView = function(viewsPath, viewPath) {
   if (!Array.isArray(viewsPath)) {
      return this._getTemplateName(path.relative(viewsPath, viewPath));
@@ -356,3 +344,15 @@ ExpressHandlebars.prototype._getView = function(viewsPath, viewPath) {
     }
   });
 }
+
+ExpressHandlebars.prototype._resolveLayoutPath = function (layoutPath) {
+    if (!layoutPath) {
+        return null;
+    }
+
+    if (!path.extname(layoutPath)) {
+        layoutPath += this.extname;
+    }
+
+    return path.resolve(this.layoutsDir, layoutPath);
+};

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -189,7 +189,7 @@ ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) 
     var view;
     var viewsPath = options.settings && options.settings.views;
     if (viewsPath) {
-        view = this._getTemplateName(path.relative(viewsPath, viewPath));
+        view = this._getView(viewsPath, viewPath);
     }
 
     // Merge render-level and instance-level helpers together.
@@ -338,3 +338,21 @@ ExpressHandlebars.prototype._resolveLayoutPath = function (layoutPath) {
 
     return path.resolve(this.layoutsDir, layoutPath);
 };
+
+ExpressHandlebars.prototype._getView = function(viewsPath, viewPath) {
+  if (!Array.isArray(viewsPath)) {
+     return this._getTemplateName(path.relative(viewsPath, viewPath));
+  }
+  
+  var self = this;
+  var stripFilename = /\/[^\/\\]+?$/;
+  
+  // Stripping filename (rather than indexOf) in case there are
+  // multiple views folders in the same parent directory
+  
+  viewsPath.forEach(function(viewDir) {
+    if (viewDir === viewPath.replace(stripFilename, '')) {
+     return self._getTemplateName(path.relative(viewDir, viewPath));
+    }
+  });
+}


### PR DESCRIPTION
Fixes #124. 

I've added a fix based on your help, and now when views is an array, res.render checks both folders (I've tested). I've tried to match the existing codebase/style as closely as possible, but there's probably still a few things you can fix (like the `_getView` comment). 

Hope it's good enough!
