### PR TITLE
Set compilerOptions to undefined by default

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -28,7 +28,7 @@ function ExpressHandlebars(config) {
         partialsDir    : 'views/partials/',
         defaultLayout  : undefined,
         helpers        : null,
-        compilerOptions: null,
+        compilerOptions: undefined,
     }, config);
 
     // Express view engine integration point.


### PR DESCRIPTION
As handlebars.js is checking options against "undefined" and then doing an "in" operator, this is throwing an error when using the defaults.