### PR TITLE
Changing default to undefined instead of null

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -28,7 +28,7 @@ function ExpressHandlebars(config) {
         partialsDir    : 'views/partials/',
         defaultLayout  : undefined,
         helpers        : null,
-        compilerOptions: null,
+        compilerOptions: undefined,
     }, config);
 
     // Express view engine integration point.


### PR DESCRIPTION
When you try to compile a template later on, it barfs on line 467 in file express-handlebars/node_modules/handlebars/dist/cjs/handlebars/compiler/compiler.js because "options" is never set to an empty object, and therefore, the "in" operator on "null" is not possible. However, it should be an empty object, but is never set to one on line 461 (in the same file) because the comparison is on "undefined" instead of "null". Therefore, changing it so the comparison succeeds.