### PR TITLE
Register partials on Handlebars global

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -29,6 +29,7 @@ function ExpressHandlebars(config) {
         defaultLayout  : undefined,
         helpers        : undefined,
         compilerOptions: undefined,
+        development    : false
     }, config);
 
     // Express view engine integration point.
@@ -45,6 +46,11 @@ function ExpressHandlebars(config) {
 
     // Private internal file system cache.
     this._fsCache = Object.create(null);
+    
+    //Setup partials on the Handlebars global
+    this.getPartials().then(function(partials) {
+      Handlebars.registerPartial(partials);
+    });
 }
 
 ExpressHandlebars.prototype.getPartials = function (options) {
@@ -95,9 +101,13 @@ ExpressHandlebars.prototype.getPartials = function (options) {
                 var partialName       = getTemplateName(filePath, namespace);
                 partials[partialName] = templates[filePath];
             });
+            
+            if (this.development) {
+              Handlebars.registerPartial(partials);
+            }
 
             return partials;
-        }, {});
+        }.bind(this), {});
     }.bind(this));
 };
 


### PR DESCRIPTION
This PR registers the partials on the Handlebars global. This makes it possible to use the `handlebars-layouts` module instead of using the layouts built into this module. In my opinion the`express-layouts` has some nice features that make it generally a more full-featured layout implementation - fairly equivalent to jade layouts.

I added a `development` flag that can be passed in. All this flag does is tell re-register the partials on every render. Turning this on makes it so that you can change one of the partials that makes up the layout and the change appears on the next render without having to restart the server.

I'm not sure that this change is even desired, but I implemented it and plan on using it on a few projects, so I figured I'd at least submit a PR. I can updated the Read Me, etc if you do want to incorporate these changes.