### PR TITLE
Bump handlebars version to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "glob": "^5.0.0",
     "graceful-fs": "^3.0.2",
-    "handlebars": "^3.0.0",
+    "handlebars": "^4.0.0",
     "object.assign": "^1.1.1",
     "promise": "^6.0.0"
   },


### PR DESCRIPTION
This includes a downstream bump to the uglify version (to 2.4.24) which fixes a vulnerability reported by the Node security project. See https://nodesecurity.io/advisories/uglifyjs_incorrectly_handles_non-boolean_comparisons for more information.

To see the compatibility notes for Handlebars 4, please go to https://github.com/wycats/handlebars.js/blob/master/release-notes.md

Thank you for your time. :)