### PR TITLE
invoke _compileTemplate with additional third arg

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -121,7 +121,7 @@ ExpressHandlebars.prototype.getTemplate = function (filePath, options) {
                 return this._precompileTemplate(file, this.compilerOptions);
             }
 
-            return this._compileTemplate(file, this.compilerOptions);
+            return this._compileTemplate(file, this.compilerOptions, filePath);
         }.bind(this));
 
     return template.catch(function (err) {
@@ -235,7 +235,8 @@ ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) 
 
 // -- Protected Hooks ----------------------------------------------------------
 
-ExpressHandlebars.prototype._compileTemplate = function (template, options) {
+ExpressHandlebars.prototype._compileTemplate = function (template, options, filePath) {
+    // filePath is an arg incase it's useful - maybe for non-handlebar stuff.
     return this.handlebars.compile(template, options);
 };
 


### PR DESCRIPTION
If the _compileTemplate() hook is invoked with an additional arg - `filePath` of the template, it means it knows the file extensions of that template. This helped me to use markdown along with express-handlebars engine in a clean way. This might be useful, in general for integrating with other markup/template technologies.

More explanation in the README of the master branch: https://github.com/kayomarz/express-handlebars.