### PR TITLE
Network templates

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 Express Handlebars Change History
 =================================
 
+3.1.0 (2016-12-08)
+------------------
+* Add capability to render network based templates and partials.
+  (All changes are backwards compatible) (@andy9775)
+
 3.0.0 (2016-01-26)
 ------------------
 

--- a/index.js
+++ b/index.js
@@ -7,10 +7,12 @@
 'use strict';
 
 var ExpressHandlebars = require('./lib/express-handlebars');
+var NetworkView       = require('./lib/networkView');
 
 exports = module.exports  = exphbs;
 exports.create            = create;
 exports.ExpressHandlebars = ExpressHandlebars;
+exports.NetworkView       = NetworkView;
 
 // -----------------------------------------------------------------------------
 

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -8,10 +8,11 @@
 
 var Promise = global.Promise || require('promise');
 
-var glob       = require('glob');
+var glob = require('glob');
 var Handlebars = require('handlebars');
-var fs         = require('graceful-fs');
-var path       = require('path');
+var fs = require('graceful-fs');
+var path = require('path');
+var request = require('request');
 
 var utils = require('./utils');
 
@@ -20,324 +21,553 @@ module.exports = ExpressHandlebars;
 // -----------------------------------------------------------------------------
 
 function ExpressHandlebars(config) {
-    // Config properties with defaults.
-    utils.assign(this, {
-        handlebars     : Handlebars,
-        extname        : '.handlebars',
-        layoutsDir     : 'views/layouts/',
-        partialsDir    : 'views/partials/',
-        defaultLayout  : undefined,
-        helpers        : undefined,
-        compilerOptions: undefined,
-    }, config);
+  // Config properties with defaults.
+  utils.assign(this, {
+    handlebars: Handlebars,
+    extname: '.handlebars',
+    layoutsDir: 'views/layouts/',
+    partialsDir: 'views/partials/',
+    layoutsAddress: undefined, // URL of layouts directory
+    partialsAddress: undefined, // URL of partials directory
+    defaultLayout: undefined,
+    helpers: undefined,
+    compilerOptions: undefined,
+  }, config);
 
-    // Express view engine integration point.
-    this.engine = this.renderView.bind(this);
+  // Express view engine integration point.
+  this.engine = this.renderView.bind(this);
 
-    // Normalize `extname`.
-    if (this.extname.charAt(0) !== '.') {
-        this.extname = '.' + this.extname;
-    }
+  // Normalize `extname`.
+  if (this.extname.charAt(0) !== '.') {
+    this.extname = '.' + this.extname;
+  }
 
-    // Internal caches of compiled and precompiled templates.
-    this.compiled    = Object.create(null);
-    this.precompiled = Object.create(null);
+  // Internal caches of compiled and precompiled templates.
+  this.compiled = Object.create(null);
+  this.precompiled = Object.create(null);
 
-    // Private internal file system cache.
-    this._fsCache = Object.create(null);
+  // Private internal file system cache.
+  this._fsCache = Object.create(null);
 }
 
-ExpressHandlebars.prototype.getPartials = function (options) {
-    var partialsDirs = Array.isArray(this.partialsDir) ?
-            this.partialsDir : [this.partialsDir];
+ExpressHandlebars.prototype.getRemotePartials = function(options) {
 
-    partialsDirs = partialsDirs.map(function (dir) {
-        var dirPath;
-        var dirTemplates;
-        var dirNamespace;
+  if (!this.partialsAddress) {
+    return;
+  }
 
-        // Support `partialsDir` collection with object entries that contain a
-        // templates promise and a namespace.
-        if (typeof dir === 'string') {
-            dirPath = dir;
-        } else if (typeof dir === 'object') {
-            dirTemplates = dir.templates;
-            dirNamespace = dir.namespace;
-            dirPath      = dir.dir;
-        }
+  var partialsAddresses = Array.isArray(this.partialsAddress) ?
+    this.partialsAddress : [this.partialsAddress]
 
-        // We must have some path to templates, or templates themselves.
-        if (!(dirPath || dirTemplates)) {
-            throw new Error('A partials dir must be a string or config object');
-        }
+  partialsAddresses = partialsAddresses
+    .map(function(address) {
+      var addPath; // URL path of templates
+      var addTemplates; // array of template names
+      var addNamespace;
 
-        // Make sure we're have a promise for the templates.
-        var templatesPromise = dirTemplates ? Promise.resolve(dirTemplates) :
-                this.getTemplates(dirPath, options);
+      if (typeof address === 'string') {
+        /*
+          assume the full address with url is passed in
+          e.g. http://localhost:3000/partials/title.handlebars
+        */
+        address = address.endsWith('/') ?
+          address.substr(0, address.length - 1) : address
+        addTemplates = [address.substr(address.lastIndexOf('/') + 1)];
+        addPath = address.substr(0, address.lastIndexOf('/')) + '/';
 
-        return templatesPromise.then(function (templates) {
-            return {
-                templates: templates,
-                namespace: dirNamespace,
-            };
+      } else if (typeof address === 'object') {
+        addTemplates = address.templates;
+        addNamespace = address.namespace;
+        addPath = address.path.endsWith('/') ?
+          address.path : address.path + '/';
+      }
+
+      /*
+        Because we cannot fetch a list of templates inside a remote directory,
+        the partials object should contain a list of templates for each path.
+        We do not traverse the partials path to fetch all partial templates!
+       */
+      if (!addPath) {
+        throw new Error('A partials address must be a string or config object');
+      }
+      if (!addTemplates) {
+        throw new Error('A partials object should have partial templates defined');
+      }
+
+      return Promise.resolve(
+        this.getRemoteTemplates(addPath, addTemplates, options))
+        .then(function(templates) {
+          return {
+            templates: templates,
+            nameSpace: addNamespace,
+          }
         });
-    }, this);
+  }, this);
 
-    return Promise.all(partialsDirs).then(function (dirs) {
-        var getTemplateName = this._getTemplateName.bind(this);
+  return Promise.all(partialsAddresses)
+    .then(function(addresses) {
+      var getTemplateName = this._getTemplateName.bind(this);
 
-        return dirs.reduce(function (partials, dir) {
-            var templates = dir.templates;
-            var namespace = dir.namespace;
-            var filePaths = Object.keys(templates);
+      return addresses
+        .reduce(function(partials, address) {
+          var templates = address.templates;
+          var namespace = address.nameSpace;
+          var addressPaths = Object.keys(templates);
 
-            filePaths.forEach(function (filePath) {
-                var partialName       = getTemplateName(filePath, namespace);
-                partials[partialName] = templates[filePath];
+          addressPaths
+            .forEach(function(addressPath) {
+              var partialName = getTemplateName(addressPath, namespace);
+              partials[partialName] = templates[addressPath];
             });
 
-            return partials;
+          return partials;
         }, {});
-    }.bind(this));
-};
+  }.bind(this));
+}
 
-ExpressHandlebars.prototype.getTemplate = function (filePath, options) {
-    filePath = path.resolve(filePath);
-    options || (options = {});
+ExpressHandlebars.prototype.getPartials = function(options) {
+  var partialsDirs = Array.isArray(this.partialsDir) ?
+    this.partialsDir : [this.partialsDir];
 
-    var precompiled = options.precompiled;
-    var cache       = precompiled ? this.precompiled : this.compiled;
-    var template    = options.cache && cache[filePath];
+  partialsDirs = partialsDirs.map(function(dir) {
+    var dirPath;
+    var dirTemplates;
+    var dirNamespace;
 
-    if (template) {
-        return template;
+    // Support `partialsDir` collection with object entries that contain a
+    // templates promise and a namespace.
+    if (typeof dir === 'string') {
+      dirPath = dir;
+    } else if (typeof dir === 'object') {
+      dirTemplates = dir.templates;
+      dirNamespace = dir.namespace;
+      dirPath = dir.dir;
     }
 
-    // Optimistically cache template promise to reduce file system I/O, but
-    // remove from cache if there was a problem.
-    template = cache[filePath] = this._getFile(filePath, {cache: options.cache})
-        .then(function (file) {
-            if (precompiled) {
-                return this._precompileTemplate(file, this.compilerOptions);
-            }
-
-            return this._compileTemplate(file, this.compilerOptions);
-        }.bind(this));
-
-    return template.catch(function (err) {
-        delete cache[filePath];
-        throw err;
-    });
-};
-
-ExpressHandlebars.prototype.getTemplates = function (dirPath, options) {
-    options || (options = {});
-    var cache = options.cache;
-
-    return this._getDir(dirPath, {cache: cache}).then(function (filePaths) {
-        var templates = filePaths.map(function (filePath) {
-            return this.getTemplate(path.join(dirPath, filePath), options);
-        }, this);
-
-        return Promise.all(templates).then(function (templates) {
-            return filePaths.reduce(function (hash, filePath, i) {
-                hash[filePath] = templates[i];
-                return hash;
-            }, {});
-        });
-    }.bind(this));
-};
-
-ExpressHandlebars.prototype.render = function (filePath, context, options) {
-    options || (options = {});
-
-    return Promise.all([
-        this.getTemplate(filePath, {cache: options.cache}),
-        options.partials || this.getPartials({cache: options.cache}),
-    ]).then(function (templates) {
-        var template = templates[0];
-        var partials = templates[1];
-        var helpers  = options.helpers || this.helpers;
-
-        // Add ExpressHandlebars metadata to the data channel so that it's
-        // accessible within the templates and helpers, namespaced under:
-        // `@exphbs.*`
-        var data = utils.assign({}, options.data, {
-            exphbs: utils.assign({}, options, {
-                filePath: filePath,
-                helpers : helpers,
-                partials: partials,
-            }),
-        });
-
-        return this._renderTemplate(template, context, {
-            data    : data,
-            helpers : helpers,
-            partials: partials,
-        });
-    }.bind(this));
-};
-
-ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) {
-    options || (options = {});
-
-    var context = options;
-
-    // Express provides `settings.views` which is the path to the views dir that
-    // the developer set on the Express app. When this value exists, it's used
-    // to compute the view's name. Layouts and Partials directories are relative
-    // to `settings.view` path
-    var view;
-    var viewsPath = options.settings && options.settings.views;
-    if (viewsPath) {
-        view = this._getTemplateName(path.relative(viewsPath, viewPath));
-        this.partialsDir = path.join(viewsPath, 'partials/');
-        this.layoutsDir = path.join(viewsPath, 'layouts/');
+    // We must have some path to templates, or templates themselves.
+    if (!(dirPath || dirTemplates)) {
+      throw new Error('A partials dir must be a string or config object');
     }
 
-    // Merge render-level and instance-level helpers together.
-    var helpers = utils.assign({}, this.helpers, options.helpers);
+    // Make sure we're have a promise for the templates.
+    var templatesPromise = dirTemplates ? Promise.resolve(dirTemplates) :
+      this.getTemplates(dirPath, options);
 
-    // Merge render-level and instance-level partials together.
-    var partials = Promise.all([
-        this.getPartials({cache: options.cache}),
-        Promise.resolve(options.partials),
-    ]).then(function (partials) {
-        return utils.assign.apply(null, [{}].concat(partials));
+    return templatesPromise.then(function(templates) {
+      return {
+        templates: templates,
+        namespace: dirNamespace,
+      };
+    });
+  }, this);
+
+  return Promise.all(partialsDirs).then(function(dirs) {
+    var getTemplateName = this._getTemplateName.bind(this);
+
+    return dirs.reduce(function(partials, dir) {
+      var templates = dir.templates;
+      var namespace = dir.namespace;
+      var filePaths = Object.keys(templates);
+
+      filePaths.forEach(function(filePath) {
+        var partialName = getTemplateName(filePath, namespace);
+        partials[partialName] = templates[filePath];
+      });
+
+      return partials;
+    }, {});
+  }.bind(this));
+};
+
+ExpressHandlebars.prototype.getTemplate = function(filePath, options) {
+  filePath = path.resolve(filePath);
+  options || (options = {});
+
+  var precompiled = options.precompiled;
+  var cache = precompiled ? this.precompiled : this.compiled;
+  var template = options.cache && cache[filePath];
+
+  if (template) {
+    return template;
+  }
+
+  // Optimistically cache template promise to reduce file system I/O, but
+  // remove from cache if there was a problem.
+  template = cache[filePath] = this._getFile(filePath, {
+    cache: options.cache
+  })
+    .then(function(file) {
+      if (precompiled) {
+        return this._precompileTemplate(file, this.compilerOptions);
+      }
+
+      return this._compileTemplate(file, this.compilerOptions);
+    }.bind(this));
+
+  return template.catch(function(err) {
+    delete cache[filePath];
+    throw err;
+  });
+};
+
+ExpressHandlebars.prototype.getRemoteTemplate = function(path, options) {
+  options || (options = {});
+  var precompiled = options.precompiled;
+  var cache = precompiled ? this.precompiled : this.compiled;
+  var template = options.cache && cache[path];
+
+  if (template) {
+    return template;
+  }
+
+  return cache[path] = this._getRemoteFile(path, {cache: options.cache})
+    .then(function(templateBody) {
+      if (precompiled) {
+        return this._precompileTemplate(templateBody, this.compilerOptions);
+      }
+      return this._compileTemplate(templateBody, this.compilerOptions);
+    }.bind(this))
+    .catch(function(err) {
+      delete cache[path];
+      throw err;
+    });
+}
+
+ExpressHandlebars.prototype.getTemplates = function(dirPath, options) {
+  options || (options = {});
+  var cache = options.cache;
+
+  return this._getDir(dirPath, {
+    cache: cache
+  }).then(function(filePaths) {
+    var templates = filePaths.map(function(filePath) {
+      return this.getTemplate(path.join(dirPath, filePath), options);
+    }, this);
+
+    return Promise.all(templates).then(function(templates) {
+      return filePaths.reduce(function(hash, filePath, i) {
+        hash[filePath] = templates[i];
+        return hash;
+      }, {});
+    });
+  }.bind(this));
+};
+
+ExpressHandlebars.prototype.getRemoteTemplates = function(path, templates, options) {
+  options || (options = {});
+
+  var templatesResult = templates
+    .map(function(template) {
+      return this.getRemoteTemplate(path + template, options);
+    }.bind(this));
+
+  return Promise.all(templatesResult)
+    .then(function(template) {
+      return templates
+        .reduce(function(partials, templatePath, i) {
+          partials[templatePath] = template[i];
+          return partials;
+        }, {});
+    });
+}
+
+ExpressHandlebars.prototype.renderFromRemote = function(path, context, options) {
+  options || (options = {});
+
+  return Promise.all([
+    this.getRemoteTemplate(path, {cache: options.cache}),
+    options.partials || this.getRemotePartials({cache: options.cache})
+  ]).then(function(templates) {
+    var template = templates[0];
+    var partials = templates[1];
+
+    var helpers = options.helpers || this.helpers;
+
+    var data = utils.assign({}, options.data, {
+      exphbs: utils.assign({}, options, {
+        filePath: path,
+        helpers: helpers,
+        partials: partials
+      }),
     });
 
-    // Pluck-out ExpressHandlebars-specific options and Handlebars-specific
-    // rendering options.
-    options = {
-        cache : options.cache,
-        view  : view,
-        layout: 'layout' in options ? options.layout : this.defaultLayout,
+    return this._renderTemplate(template, context, {
+      data: data,
+      helpers: helpers,
+      partials: partials,
+    });
+  }.bind(this));
+}
 
-        data    : options.data,
-        helpers : helpers,
+ExpressHandlebars.prototype.renderFromFile = function(filePath, context, options) {
+  options || (options = {});
+
+  return Promise.all([
+    this.getTemplate(filePath, {
+      cache: options.cache
+    }),
+    options.partials || this.getPartials({
+      cache: options.cache
+    }),
+  ]).then(function(templates) {
+    var template = templates[0];
+    var partials = templates[1];
+    var helpers = options.helpers || this.helpers;
+
+    // Add ExpressHandlebars metadata to the data channel so that it's
+    // accessible within the templates and helpers, namespaced under:
+    // `@exphbs.*`
+    var data = utils.assign({}, options.data, {
+      exphbs: utils.assign({}, options, {
+        filePath: filePath,
+        helpers: helpers,
         partials: partials,
-    };
+      }),
+    });
 
-    this.render(viewPath, context, options)
-        .then(function (body) {
-            var layoutPath = this._resolveLayoutPath(options.layout);
+    return this._renderTemplate(template, context, {
+      data: data,
+      helpers: helpers,
+      partials: partials,
+    });
+  }.bind(this));
+};
 
-            if (layoutPath) {
-                return this.render(
-                    layoutPath,
-                    utils.assign({}, context, {body: body}),
-                    utils.assign({}, options, {layout: undefined})
-                );
-            }
+ExpressHandlebars.prototype.renderRemoteView = function(viewPath, options, callback) {
 
-            return body;
-        }.bind(this))
-        .then(utils.passValue(callback))
-        .catch(utils.passError(callback));
+  var view; // view name e.g. index.handlebars
+  var viewsPath = options.settings && options.settings.views; // URL to views
+
+  if (viewsPath) {
+    viewsPath = viewsPath.endsWith('/') ?
+      viewsPath : (viewsPath + '/');
+    view = viewPath.replace(viewsPath, '');
+  }
+
+  var helpers = utils.assign({}, this.helpers, options.helpers);
+
+  // Merge render-level and instance-level partials together.
+  var partials = Promise.all([
+    this.getRemotePartials({cache: options.cache}),
+    Promise.resolve(options.partials), // if cached
+  ]).then(function(partials) {
+    return utils.assign.apply(null, [{}].concat(partials));
+  });
+
+  var context = options;
+  options = {
+    cache: options.cache,
+    view: view,
+    layout: 'layout' in options ? options.layout : this.defaultLayout,
+
+    data: options.data,
+    helpers: helpers,
+    partials: partials,
+  };
+
+  this.renderFromRemote(viewPath, context, options)
+    .then(utils.passValue(callback))
+    .catch(utils.passError(callback));
+}
+
+ExpressHandlebars.prototype.renderLocalView = function(viewPath, options, callback) {
+  options || (options = {});
+
+  var context = options;
+
+  // Express provides `settings.views` which is the path to the views dir that
+  // the developer set on the Express app. When this value exists, it's used
+  // to compute the view's name. Layouts and Partials directories are relative
+  // to `settings.view` path
+  var view;
+  var viewsPath = options.settings && options.settings.views;
+  if (viewsPath) {
+    view = this._getTemplateName(path.relative(viewsPath, viewPath));
+    this.partialsDir = path.join(viewsPath, 'partials/');
+    this.layoutsDir = path.join(viewsPath, 'layouts/');
+  }
+
+  // Merge render-level and instance-level helpers together.
+  var helpers = utils.assign({}, this.helpers, options.helpers);
+
+  // Merge render-level and instance-level partials together.
+  var partials = Promise.all([
+    this.getPartials({
+      cache: options.cache
+    }),
+    Promise.resolve(options.partials),
+  ]).then(function(partials) {
+    return utils.assign.apply(null, [{}].concat(partials));
+  });
+
+  // Pluck-out ExpressHandlebars-specific options and Handlebars-specific
+  // rendering options.
+  options = {
+    cache: options.cache,
+    view: view,
+    layout: 'layout' in options ? options.layout : this.defaultLayout,
+
+    data: options.data,
+    helpers: helpers,
+    partials: partials,
+  };
+
+
+  this.renderFromFile(viewPath, context, options)
+    .then(function(body) {
+      var layoutPath = this._resolveLayoutPath(options.layout);
+
+      if (layoutPath) {
+        return this.renderFromFile(
+          layoutPath,
+          utils.assign({}, context, {
+            body: body
+          }),
+          utils.assign({}, options, {
+            layout: undefined
+          })
+        );
+      }
+
+      return body;
+    }.bind(this))
+    .then(utils.passValue(callback))
+    .catch(utils.passError(callback));
+}
+
+ExpressHandlebars.prototype.renderView = function(viewPath, options, callback) {
+  if (this.layoutsAddress) {
+    this.renderRemoteView(viewPath, options, callback);
+  } else {
+    this.renderLocalView(viewPath, options, callback);
+  }
 };
 
 // -- Protected Hooks ----------------------------------------------------------
 
-ExpressHandlebars.prototype._compileTemplate = function (template, options) {
-    return this.handlebars.compile(template, options);
+ExpressHandlebars.prototype._compileTemplate = function(template, options) {
+  return this.handlebars.compile(template, options);
 };
 
-ExpressHandlebars.prototype._precompileTemplate = function (template, options) {
-    return this.handlebars.precompile(template, options);
+ExpressHandlebars.prototype._precompileTemplate = function(template, options) {
+  return this.handlebars.precompile(template, options);
 };
 
-ExpressHandlebars.prototype._renderTemplate = function (template, context, options) {
-    return template(context, options);
+ExpressHandlebars.prototype._renderTemplate = function(template, context, options) {
+  return template(context, options);
 };
 
 // -- Private ------------------------------------------------------------------
 
-ExpressHandlebars.prototype._getDir = function (dirPath, options) {
-    dirPath = path.resolve(dirPath);
-    options || (options = {});
+ExpressHandlebars.prototype._getDir = function(dirPath, options) {
+  dirPath = path.resolve(dirPath);
+  options || (options = {});
 
-    var cache = this._fsCache;
-    var dir   = options.cache && cache[dirPath];
+  var cache = this._fsCache;
+  var dir = options.cache && cache[dirPath];
 
-    if (dir) {
-        return dir.then(function (dir) {
-            return dir.concat();
-        });
-    }
-
-    var pattern = '**/*' + this.extname;
-
-    // Optimistically cache dir promise to reduce file system I/O, but remove
-    // from cache if there was a problem.
-    dir = cache[dirPath] = new Promise(function (resolve, reject) {
-        glob(pattern, {
-            cwd   : dirPath,
-            follow: true
-        }, function (err, dir) {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(dir);
-            }
-        });
+  if (dir) {
+    return dir.then(function(dir) {
+      return dir.concat();
     });
+  }
 
-    return dir.then(function (dir) {
-        return dir.concat();
-    }).catch(function (err) {
-        delete cache[dirPath];
-        throw err;
+  var pattern = '**/*' + this.extname;
+
+  // Optimistically cache dir promise to reduce file system I/O, but remove
+  // from cache if there was a problem.
+  dir = cache[dirPath] = new Promise(function(resolve, reject) {
+    glob(pattern, {
+      cwd: dirPath,
+      follow: true
+    }, function(err, dir) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(dir);
+      }
     });
+  });
+
+  return dir.then(function(dir) {
+    return dir.concat();
+  }).catch(function(err) {
+    delete cache[dirPath];
+    throw err;
+  });
 };
 
-ExpressHandlebars.prototype._getFile = function (filePath, options) {
-    filePath = path.resolve(filePath);
-    options || (options = {});
+ExpressHandlebars.prototype._getRemoteFile = function(path, options) {
+  options || (options = {});
+  var cache = this._fsCache;
+  var file = options.cache && cache[path];
 
-    var cache = this._fsCache;
-    var file  = options.cache && cache[filePath];
+  if (file) {
+    return file;
+  }
 
-    if (file) {
-        return file;
-    }
-
-    // Optimistically cache file promise to reduce file system I/O, but remove
-    // from cache if there was a problem.
-    file = cache[filePath] = new Promise(function (resolve, reject) {
-        fs.readFile(filePath, 'utf8', function (err, file) {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(file);
-            }
-        });
+  return cache[path] = new Promise(function(resolve, reject) {
+    request(path, function(err, response, body) {
+      if (err || response.statusCode !== 200) {
+        reject(err);
+      }
+      resolve(body);
+    }.bind(this));
+  })
+    .catch(function(err) {
+      delete cache[path];
+      throw err;
     });
+}
 
-    return file.catch(function (err) {
-        delete cache[filePath];
-        throw err;
+ExpressHandlebars.prototype._getFile = function(filePath, options) {
+  filePath = path.resolve(filePath);
+  options || (options = {});
+
+  var cache = this._fsCache;
+  var file = options.cache && cache[filePath];
+
+  if (file) {
+    return file;
+  }
+
+  // Optimistically cache file promise to reduce file system I/O, but remove
+  // from cache if there was a problem.
+  file = cache[filePath] = new Promise(function(resolve, reject) {
+    fs.readFile(filePath, 'utf8', function(err, file) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(file);
+      }
     });
+  });
+
+  return file.catch(function(err) {
+    delete cache[filePath];
+    throw err;
+  });
 };
 
-ExpressHandlebars.prototype._getTemplateName = function (filePath, namespace) {
-    var extRegex = new RegExp(this.extname + '$');
-    var name     = filePath.replace(extRegex, '');
+ExpressHandlebars.prototype._getTemplateName = function(filePath, namespace) {
+  var extRegex = new RegExp(this.extname + '$');
+  var name = filePath.replace(extRegex, '');
 
-    if (namespace) {
-        name = namespace + '/' + name;
-    }
+  if (namespace) {
+    name = namespace + '/' + name;
+  }
 
-    return name;
+  return name;
 };
 
-ExpressHandlebars.prototype._resolveLayoutPath = function (layoutPath) {
-    if (!layoutPath) {
-        return null;
-    }
+ExpressHandlebars.prototype._resolveLayoutPath = function(layoutPath) {
+  if (!layoutPath) {
+    return null;
+  }
 
-    if (!path.extname(layoutPath)) {
-        layoutPath += this.extname;
-    }
+  if (!path.extname(layoutPath)) {
+    layoutPath += this.extname;
+  }
 
-    return path.resolve(this.layoutsDir, layoutPath);
+  return path.resolve(this.layoutsDir, layoutPath);
 };

--- a/lib/networkView.js
+++ b/lib/networkView.js
@@ -1,5 +1,4 @@
 var View = require('express/lib/view');
-var path = require('path');
 
 var NetworkView = function(name, options) {
   View.call(this, name, options);
@@ -13,6 +12,9 @@ NetworkView.prototype.lookup = function(name) {
 }
 
 NetworkView.prototype.join = function(root, name) {
+  root = root[root.length - 1] === '/' ?
+    root.slice(0, root.length - 1) : root;
+    
   return root + (name[0] === '/' ? name : ('/' + name));
 }
 

--- a/lib/networkView.js
+++ b/lib/networkView.js
@@ -1,0 +1,19 @@
+var View = require('express/lib/view');
+var path = require('path');
+
+var NetworkView = function(name, options) {
+  View.call(this, name, options);
+};
+
+NetworkView.prototype = Object.create(View.prototype);
+NetworkView.prototype.constructor = NetworkView;
+
+NetworkView.prototype.lookup = function(name) {
+  return View.prototype.lookup.call(this, name) || this.join(this.root, name);
+}
+
+NetworkView.prototype.join = function(root, name) {
+  return root + (name[0] === '/' ? name : ('/' + name));
+}
+
+module.exports = NetworkView;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-handlebars",
   "description": "A Handlebars view engine for Express which doesn't suck.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "homepage": "https://github.com/ericf/express-handlebars",
   "keywords": [
     "express",
@@ -24,11 +24,13 @@
     "node": ">=0.10"
   },
   "dependencies": {
+    "express": "^4.14.0",
     "glob": "^6.0.4",
     "graceful-fs": "^4.1.2",
     "handlebars": "^4.0.5",
     "object.assign": "^4.0.3",
-    "promise": "^7.0.0"
+    "promise": "^7.0.0",
+    "request": "^2.79.0"
   },
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
I added the ability to fetch handlebars templates from a remote resource. This is useful if using webpack dev server with `HtmlWebPackPlugin` to generate our handlebars templates. This can also be used in production if you have network based templates.

This PR is backwards compatible with existing configuration and does not break anything.