### PR TITLE
Fix for issue #161: Can you trim first char code 65379?

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -308,7 +308,7 @@ ExpressHandlebars.prototype._getFile = function (filePath, options) {
             if (err) {
                 reject(err);
             } else {
-               if ( file && file.charCodeAt(0) === 65279) {
+               if ( file && file.charCodeAt(0) > 255) {
                     //remove BOM when fs does not
                     file = file.substring(1);
                }

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -308,7 +308,11 @@ ExpressHandlebars.prototype._getFile = function (filePath, options) {
             if (err) {
                 reject(err);
             } else {
-                resolve(file);
+               if ( file && file.charCodeAt(0) === 65279) {
+                    //remove BOM when fs does not
+                    file = file.substring(1);
+               }
+               resolve(file);
             }
         });
     });


### PR DESCRIPTION
This issue appears when using express-handlebars on any windows file system.  The change removes the BOM for utf-8 when fs does not.