### PR TITLE
Solve issue #244

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -192,13 +192,13 @@ ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) 
     if (viewsPath) {
         view = this._getTemplateName(path.relative(viewsPath, viewPath));
         
-        if(Array.isArray(this.partialsDir)) {
+        if (Array.isArray(this.partialsDir)) {
           this.partialsDir.push(path.join(viewsPath, 'partials/'));
         } else {
           this.partialsDir = [this.partialsDir || path.join(viewsPath, 'partials/')];
         }
 
-        if(Array.isArray(this.layoutsDir)) {
+        if (Array.isArray(this.layoutsDir)) {
           this.layoutsDir.push(path.join(viewsPath, 'layouts/'));
         } else {
           this.layoutsDir = [this.partialsDir || path.join(viewsPath, 'layouts/')];

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -191,8 +191,18 @@ ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) 
     var viewsPath = options.settings && options.settings.views;
     if (viewsPath) {
         view = this._getTemplateName(path.relative(viewsPath, viewPath));
-        this.partialsDir = path.join(viewsPath, 'partials/');
-        this.layoutsDir = path.join(viewsPath, 'layouts/');
+        
+        if(Array.isArray(this.partialsDir)) {
+          this.partialsDir.push(path.join(viewsPath, 'partials/'));
+        } else {
+          this.partialsDir = [this.partialsDir || path.join(viewsPath, 'partials/')];
+        }
+
+        if(Array.isArray(this.layoutsDir)) {
+          this.layoutsDir.push(path.join(viewsPath, 'layouts/'));
+        } else {
+          this.layoutsDir = [this.partialsDir || path.join(viewsPath, 'layouts/')];
+        }
     }
 
     // Merge render-level and instance-level helpers together.


### PR DESCRIPTION
Solve issue #244. When `viewsPath` is truthy, the `partialsDir` which have the directories defined by the user on the constructor, are overwritten by as single String `path.join(viewsPath, 'partials/')`. I'm playing safe here, I assume `partialsDir` is internally always dealt as an Array and therefore I convert it to an Array, pushing when appropriate the default `path.join(viewsPath, 'partials/')`, but keeping the previously defined `partialDirs`