### PR TITLE
Update express-handlebars.js

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -48,6 +48,8 @@ function ExpressHandlebars(config) {
 }
 
 ExpressHandlebars.prototype.getPartials = function (options) {
+    if (typof this.partialsDir === 'undefined') return;
+    
     var partialsDirs = Array.isArray(this.partialsDir) ?
             this.partialsDir : [this.partialsDir];
 


### PR DESCRIPTION
As of 3.0.2, the initial assignment of partialsDir is no longer defaulted to 'views/partials/'. This breaks systems which only use layoutsDir. This PR fixes this use case.