### PR TITLE
Allow express-handlebars to take an array of views

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -188,7 +188,26 @@ ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) 
     // to compute the view's name. Layouts and Partials directories are relative
     // to `settings.view` path
     var view;
-    var viewsPath = options.settings && options.settings.views;
+    
+    // expects a string for the views path configured in app.set("views", "the_path...")
+    // var viewsPath = options.settings && options.settings.views;
+    
+    // proposed change that allows an array of "views" directories to be passed in to app.set(...)
+    // will loop through the array and the last matching in the array will be used as the directory
+    // order of directories is important
+    var viewsPath = (function (_viewsPath, _viewPath) {
+      // if we have a string for the "views" directory return it
+      if (typeof _viewsPath === 'string') return _viewsPath;
+      var result;
+      var _viewPathDir = _viewPath.substring(0, _viewPath.lastIndexOf('/'));
+      _viewsPath.forEach(dir => {
+        if (dir === _viewPathDir && path.relative(dir, _viewPath).split('.').length > 1) {
+          result = dir;
+        }
+      })
+      return result;
+    })(options.settings && options.settings.views, viewPath);
+    
     if (viewsPath) {
         view = this._getTemplateName(path.relative(viewsPath, viewPath));
         this.partialsDir = this.partialsDir || path.join(viewsPath, 'partials/');


### PR DESCRIPTION
the proposed change is a first pass at allowing express-handlebars to accept an array of views directories. I'm not sure if the project maintainer(s) are open to the feature. I have tested this with an array of paths and a single string and it works as expected.