### PR TITLE
feat(partials): Parse function to (re)name partials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ The string path to the directory where the partials templates reside or object w
 * `dir`: The string path to the directory where the partials templates reside.
 * `namespace`: Optional string namespace to prefix the partial names.
 * `templates`: Optional collection (or promise of a collection) of templates in the form: `{filename: template}`.
+* `rename(filePath, namespace)`: Optional function to rename the partials. Takes two arguments: `filePath`, e.g., `partials/template.handlebars` and `namespace`.
 
 **Note:** If you configure Express to look for views in a custom location (e.g., `app.set('views', 'some/path/')`), and if your `partialsDir` is not relative to `express settings.view` + `partials/`, you will need to reflect that by passing an updated path as the `partialsDir` property in your configuration.
 

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -55,6 +55,7 @@ ExpressHandlebars.prototype.getPartials = function (options) {
         var dirPath;
         var dirTemplates;
         var dirNamespace;
+        var dirRename;
 
         // Support `partialsDir` collection with object entries that contain a
         // templates promise and a namespace.
@@ -64,6 +65,7 @@ ExpressHandlebars.prototype.getPartials = function (options) {
             dirTemplates = dir.templates;
             dirNamespace = dir.namespace;
             dirPath      = dir.dir;
+            dirRename    = dir.rename;
         }
 
         // We must have some path to templates, or templates themselves.
@@ -79,6 +81,7 @@ ExpressHandlebars.prototype.getPartials = function (options) {
             return {
                 templates: templates,
                 namespace: dirNamespace,
+                rename: dirRename,
             };
         });
     }, this);
@@ -89,10 +92,14 @@ ExpressHandlebars.prototype.getPartials = function (options) {
         return dirs.reduce(function (partials, dir) {
             var templates = dir.templates;
             var namespace = dir.namespace;
+            var rename    = dir.rename;
             var filePaths = Object.keys(templates);
 
+            var getTemplateNameFn = typeof rename === 'function'
+                ? rename : getTemplateName;
+
             filePaths.forEach(function (filePath) {
-                var partialName       = getTemplateName(filePath, namespace);
+                var partialName       = getTemplateNameFn(filePath, namespace);
                 partials[partialName] = templates[filePath];
             });
 


### PR DESCRIPTION
We need more flexibility when it comes to naming partials and don't want to be constrained by our folder structure.

For example, we have

```
/components
    /button
        button.hbs
    /template
        otherTemplate.hbs
```

Currently, this names the partial `button/button` and `template/otherTemplate`.

This renaming function allows more flexibility, e.g., naming the two templates `button` and `otherTemplate`, ignoring the folder structure.